### PR TITLE
User Story 5: Setting Personal Deduction by Admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ POSTGRES_URL=postgres://postgres:postgres@localhost:5432/ktaxes?sslmode=disable
 migrateup:
 	migrate -path db/migration -database "$(POSTGRES_URL)" -verbose up
 
+migratedown:
+	migrate -path db/migration -database "$(POSTGRES_URL)" -verbose down
+
 mock:
 	mockgen -package=mockdb -source="db/store.go" -destination="db/mock/store.go" Store
 

--- a/api/admin.go
+++ b/api/admin.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"database/sql"
+	"errors"
 	"github.com/danyouknowme/assessment-tax/db"
 	"github.com/labstack/echo/v4"
 	"net/http"
@@ -24,6 +26,12 @@ func (s *Server) SettingPersonalDeduction(c echo.Context) error {
 		},
 	)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			err := errors.New("personal deduction not found")
+			return c.JSON(http.StatusNotFound, errorResponse(err))
+		}
+
+		err := errors.New("failed to update personal deduction")
 		return c.JSON(http.StatusInternalServerError, errorResponse(err))
 	}
 

--- a/api/admin.go
+++ b/api/admin.go
@@ -1,12 +1,33 @@
 package api
 
 import (
+	"github.com/danyouknowme/assessment-tax/db"
 	"github.com/labstack/echo/v4"
 	"net/http"
 )
 
+type SettingPersonalDeductionRequest struct {
+	Amount float64 `json:"amount"`
+}
+
 func (s *Server) SettingPersonalDeduction(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"message": "personal deduction set successfully",
+	var req SettingPersonalDeductionRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, errorResponse(err))
+	}
+
+	deduction, err := s.store.UpdateDeductionByType(
+		c.Request().Context(),
+		"personal",
+		db.UpdateDeductionParams{
+			Amount: req.Amount,
+		},
+	)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errorResponse(err))
+	}
+
+	return c.JSON(http.StatusOK, map[string]float64{
+		"personalDeduction": deduction.Amount,
 	})
 }

--- a/api/admin.go
+++ b/api/admin.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/labstack/echo/v4"
+	"net/http"
+)
+
+func (s *Server) SettingPersonalDeduction(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"message": "personal deduction set successfully",
+	})
+}

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"github.com/danyouknowme/assessment-tax/config"
+	"github.com/danyouknowme/assessment-tax/db"
+	mockdb "github.com/danyouknowme/assessment-tax/db/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAdminSetPersonalDeductionAPI(t *testing.T) {
+	testCases := []struct {
+		name          string
+		body          map[string]float64
+		setupAuth     func(request *http.Request)
+		buildStubs    func(store *mockdb.MockStore)
+		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name: "OK",
+			body: map[string]float64{
+				"amount": 70000.0,
+			},
+			setupAuth: func(request *http.Request) {
+				request.SetBasicAuth("adminTest", "test!")
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					UpdateDeductionByType(gomock.Any(), gomock.Any(), db.UpdateDeductionParams{Amount: 70000.0}).
+					Times(1).
+					Return(&db.Deduction{Type: "personal", Amount: 70000.0}, nil)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+
+				expected := `{"personalDeduction":70000}`
+				require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(recorder.Body.String()))
+			},
+		},
+		{
+			name: "Not Found Personal Deduction",
+			body: map[string]float64{
+				"amount": 70000.0,
+			},
+			setupAuth: func(request *http.Request) {
+				request.SetBasicAuth("adminTest", "test!")
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					UpdateDeductionByType(gomock.Any(), gomock.Any(), db.UpdateDeductionParams{Amount: 70000.0}).
+					Times(1).
+					Return(nil, sql.ErrNoRows)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusNotFound, recorder.Code)
+			},
+		},
+		{
+			name: "Failed to Update Personal Deduction",
+			body: map[string]float64{
+				"amount": 70000.0,
+			},
+			setupAuth: func(request *http.Request) {
+				request.SetBasicAuth("adminTest", "test!")
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					UpdateDeductionByType(gomock.Any(), gomock.Any(), db.UpdateDeductionParams{Amount: 70000.0}).
+					Times(1).
+					Return(nil, sql.ErrConnDone)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusInternalServerError, recorder.Code)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			store := mockdb.NewMockStore(ctrl)
+			tc.buildStubs(store)
+
+			cfg := config.Config{
+				AdminUsername: "adminTest",
+				AdminPassword: "test!",
+			}
+
+			server := NewServer(&cfg, store)
+			recorder := httptest.NewRecorder()
+
+			data, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+
+			url := "/admin/deductions/personal"
+			request, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+			require.NoError(t, err)
+
+			request.Header.Set("Content-Type", "application/json")
+
+			tc.setupAuth(request)
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
+		})
+	}
+}

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,0 +1,1 @@
+package api

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,1 +1,24 @@
 package api
+
+import (
+	"errors"
+	"github.com/labstack/echo/v4"
+	"net/http"
+)
+
+func (s *Server) basicAuth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		u, p, ok := c.Request().BasicAuth()
+		if !ok {
+			err := errors.New("missing basic auth")
+			return c.JSON(http.StatusUnauthorized, errorResponse(err))
+		}
+
+		if u != s.config.AdminUsername || p != s.config.AdminPassword {
+			err := errors.New("invalid username or password")
+			return c.JSON(http.StatusUnauthorized, errorResponse(err))
+		}
+
+		return next(c)
+	}
+}

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -12,12 +12,12 @@ import (
 func TestBasicAuthMiddleware(t *testing.T) {
 	testCases := []struct {
 		name          string
-		setupAuth     func(t *testing.T, request *http.Request)
+		setupAuth     func(request *http.Request)
 		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
 	}{
 		{
 			name: "OK",
-			setupAuth: func(t *testing.T, request *http.Request) {
+			setupAuth: func(request *http.Request) {
 				request.SetBasicAuth("adminTest", "test!")
 			},
 			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
@@ -26,14 +26,14 @@ func TestBasicAuthMiddleware(t *testing.T) {
 		},
 		{
 			name:      "Missing Basic Auth",
-			setupAuth: func(t *testing.T, request *http.Request) {},
+			setupAuth: func(request *http.Request) {},
 			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				require.Equal(t, http.StatusUnauthorized, recorder.Code)
 			},
 		},
 		{
 			name: "Invalid Username or Password",
-			setupAuth: func(t *testing.T, request *http.Request) {
+			setupAuth: func(request *http.Request) {
 				request.SetBasicAuth("adminTest", "wrongPassword")
 			},
 			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
@@ -58,7 +58,7 @@ func TestBasicAuthMiddleware(t *testing.T) {
 			request, err := http.NewRequest(http.MethodGet, "/auth", nil)
 			require.NoError(t, err)
 
-			tc.setupAuth(t, request)
+			tc.setupAuth(request)
 			server.router.ServeHTTP(recorder, request)
 			tc.checkResponse(t, recorder)
 		})

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"github.com/danyouknowme/assessment-tax/config"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBasicAuthMiddleware(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setupAuth     func(t *testing.T, request *http.Request)
+		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name: "OK",
+			setupAuth: func(t *testing.T, request *http.Request) {
+				request.SetBasicAuth("adminTest", "test!")
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+			},
+		},
+		{
+			name:      "Missing Basic Auth",
+			setupAuth: func(t *testing.T, request *http.Request) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Username or Password",
+			setupAuth: func(t *testing.T, request *http.Request) {
+				request.SetBasicAuth("adminTest", "wrongPassword")
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusUnauthorized, recorder.Code)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{
+				AdminUsername: "adminTest",
+				AdminPassword: "test!",
+			}
+			server := NewServer(&cfg, nil)
+
+			server.router.GET("/auth", server.basicAuth(func(c echo.Context) error {
+				return c.String(http.StatusOK, "OK")
+			}))
+
+			recorder := httptest.NewRecorder()
+			request, err := http.NewRequest(http.MethodGet, "/auth", nil)
+			require.NoError(t, err)
+
+			tc.setupAuth(t, request)
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
+		})
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -29,6 +29,7 @@ func (s *Server) setupRouter() {
 	e := echo.New()
 
 	e.POST("/tax/calculations", s.CalculateTax)
+	e.POST("/admin/deductions/personal", s.basicAuth(s.SettingPersonalDeduction))
 
 	s.router = e
 }

--- a/db/migration/01_init_schema.down.sql
+++ b/db/migration/01_init_schema.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS "deductions";
+
+DROP TYPE IF EXISTS deduction_type;

--- a/db/migration/01_init_schema.up.sql
+++ b/db/migration/01_init_schema.up.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS "deductions" (
     "id" SERIAL PRIMARY KEY,
     "type" deduction_type NOT NULL,
     "amount" DECIMAL(10, 2) NOT NULL,
-    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 INSERT INTO "deductions" ("type", "amount") VALUES ('personal', 60000.00);

--- a/db/mock/store.go
+++ b/db/mock/store.go
@@ -64,3 +64,18 @@ func (mr *MockStoreMockRecorder) GetDeductionByType(ctx, deductionType interface
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeductionByType", reflect.TypeOf((*MockStore)(nil).GetDeductionByType), ctx, deductionType)
 }
+
+// UpdateDeductionByType mocks base method.
+func (m *MockStore) UpdateDeductionByType(ctx context.Context, deductionType string, arg db.UpdateDeductionParams) (*db.Deduction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDeductionByType", ctx, deductionType, arg)
+	ret0, _ := ret[0].(*db.Deduction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDeductionByType indicates an expected call of UpdateDeductionByType.
+func (mr *MockStoreMockRecorder) UpdateDeductionByType(ctx, deductionType, arg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeductionByType", reflect.TypeOf((*MockStore)(nil).UpdateDeductionByType), ctx, deductionType, arg)
+}

--- a/db/models.go
+++ b/db/models.go
@@ -4,3 +4,7 @@ type Deduction struct {
 	Type   string
 	Amount float64
 }
+
+type UpdateDeductionParams struct {
+	Amount float64 `json:"amount"`
+}


### PR DESCRIPTION
### As admin, I want to setting personal deduction(ในฐานะ Admin ฉันต้องการตั้งค่าลดหย่อนส่วนตัว)

- [x] แอดมินสามารถตั้งค่า ค่าลดหย่อนส่วนตัวได้
- [x] สร้าง basic auth middleware, ใช้ username และ password จาก env
- [x] เพิ่ม unit tests สำหรับ basic auth middleware
- [x] สร้าง API สำหรับให้แอดมินตั้งค่า ค่าลดหย่อนส่วนตัว
- [x] เพิ่ม unit tests สำหรับ API ให้แอดมิน set ค่าลดหย่อนส่วนตัว
- [x] เพิ่ม field updated_at ในตาราง deduction ใน db

###### Example Request
```json
{
  "amount": 70000.0
}
```
###### Example Response
```json
{
  "personalDeduction": 70000.0
}
```