### PR TITLE
Refund Tax

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -9,12 +9,16 @@ import (
 )
 
 type SettingPersonalDeductionRequest struct {
-	Amount float64 `json:"amount"`
+	Amount float64 `json:"amount" validate:"required,min=0.0"`
 }
 
 func (s *Server) SettingPersonalDeduction(c echo.Context) error {
 	var req SettingPersonalDeductionRequest
 	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, errorResponse(err))
+	}
+
+	if err := c.Validate(req); err != nil {
 		return c.JSON(http.StatusBadRequest, errorResponse(err))
 	}
 

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -45,6 +45,30 @@ func TestAdminSetPersonalDeductionAPI(t *testing.T) {
 			},
 		},
 		{
+			name: "Invalid Body(Missing Amount)",
+			body: map[string]float64{},
+			setupAuth: func(request *http.Request) {
+				request.SetBasicAuth("adminTest", "test!")
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Body(Negative Amount)",
+			body: map[string]float64{
+				"amount": -70000.0,
+			},
+			setupAuth: func(request *http.Request) {
+				request.SetBasicAuth("adminTest", "test!")
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
 			name: "Not Found Personal Deduction",
 			body: map[string]float64{
 				"amount": 70000.0,

--- a/api/tax_test.go
+++ b/api/tax_test.go
@@ -50,6 +50,91 @@ func TestCalculateTaxAPI(t *testing.T) {
 			},
 		},
 		{
+			name: "Invalid Body(Missing TotalIncome)",
+			body: map[string]interface{}{
+				"wht":        0.0,
+				"allowances": []map[string]interface{}{},
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Body(TotalIncome is negative)",
+			body: map[string]interface{}{
+				"totalIncome": -500000.0,
+				"allowances":  []map[string]interface{}{},
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Body(WHT is negative)",
+			body: map[string]interface{}{
+				"totalIncome": 500000.0,
+				"wht":         -100000.0,
+				"allowances":  []map[string]interface{}{},
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Body(Wht more than TotalIncome)",
+			body: map[string]interface{}{
+				"totalIncome": 500000.0,
+				"wht":         1000000.0,
+				"allowances": []map[string]interface{}{
+					{
+						"allowanceType": "donation",
+						"amount":        200000.0,
+					},
+				},
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Body(Invalid Allowance Type)",
+			body: map[string]interface{}{
+				"totalIncome": 500000.0,
+				"wht":         0.0,
+				"allowances": []map[string]interface{}{
+					{
+						"allowanceType": "invalid",
+						"amount":        200000.0,
+					},
+				},
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
+			name: "Invalid Body(Invalid Allowance Amount)",
+			body: map[string]interface{}{
+				"totalIncome": 500000.0,
+				"wht":         0.0,
+				"allowances": []map[string]interface{}{
+					{
+						"allowanceType": "donation",
+						"amount":        -200000.0,
+					},
+				},
+			},
+			buildStubs: func(store *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+		{
 			name: "Not Found Default Deductions",
 			body: map[string]interface{}{
 				"totalIncome": 500000.0,

--- a/api/validator.go
+++ b/api/validator.go
@@ -37,6 +37,6 @@ func registerWhtValidation(v *validator.Validate) error {
 	return v.RegisterValidation("wht_custom_validation", func(fl validator.FieldLevel) bool {
 		wht := fl.Field().Float()
 		totalIncome := fl.Parent().FieldByName("TotalIncome").Float()
-		return wht > 0 && wht < totalIncome
+		return wht >= 0 && wht < totalIncome
 	})
 }

--- a/tax/tax.go
+++ b/tax/tax.go
@@ -8,16 +8,16 @@ import (
 
 type CalculationRequest struct {
 	TotalIncome float64     `json:"totalIncome" validate:"required,min=0.0"`
-	Wht         float64     `json:"wht" validate:"min=0.0"`
-	Allowances  []Allowance `json:"allowances"`
+	Wht         float64     `json:"wht" validate:"wht_custom_validation"`
+	Allowances  []Allowance `json:"allowances" validate:"dive"`
 }
 
 type Allowance struct {
-	AllowanceType string  `json:"allowanceType"`
-	Amount        float64 `json:"amount"`
+	AllowanceType string  `json:"allowanceType" validate:"allowance_type_custom_validation"`
+	Amount        float64 `json:"amount" validate:"min=0.0"`
 }
 
-func Calculate(defaultDeductions []db.Deduction, req CalculationRequest) float64 {
+func Calculate(defaultDeductions []db.Deduction, req CalculationRequest) (float64, float64) {
 	var tax float64 = 0
 
 	donationAllowance := calculateDonationAllowance(getDeductionByType(defaultDeductions, "donation").Amount, req.Allowances)
@@ -37,7 +37,11 @@ func Calculate(defaultDeductions []db.Deduction, req CalculationRequest) float64
 
 	tax -= req.Wht
 
-	return formatCalculatedTax(tax)
+	if tax < 0 {
+		return 0, formatCalculatedTax(tax * -1)
+	}
+
+	return formatCalculatedTax(tax), 0
 }
 
 type TaxLevel struct {


### PR DESCRIPTION
### Refund Tax

- [x] Fix calculate tax function to return refund tax value
- [x] Add unit tests in case of invalid body in each API
- [x] Returning tax refund, and disabling tax level

##### Example Request
```json
{
  "totalIncome": 500000.0,
  "wht": 100000.0,
  "allowances": [
    {
      "allowanceType": "donation",
      "amount": 200000.0
    }
  ]
}
```
##### Example Response
```json
{
    "tax": 0,
    "taxRefund": 81000,
    "taxLevel": null
}
```
