### PR TITLE
User Story 7: Calculate tax with k-receipt allowance

### DIFF
--- a/db/migration/01_init_schema.up.sql
+++ b/db/migration/01_init_schema.up.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS "deductions" (
     "type" deduction_type NOT NULL,
     "amount" DECIMAL(10, 2) NOT NULL,
     "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_deduction_type UNIQUE ("type")
 );
 
 INSERT INTO "deductions" ("type", "amount") VALUES ('personal', 60000.00);

--- a/tax/tax_test.go
+++ b/tax/tax_test.go
@@ -254,6 +254,43 @@ func TestCalculateTaxWithDonationAllowances(t *testing.T) {
 	}
 }
 
+func TestCalculateTaxWithKReceiptAllowances(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "Total income 500,000 WHT 0.0 k-receipt 200,000 and donation 100,000 should return 14,000",
+			input: CalculationRequest{
+				TotalIncome: 500000.0,
+				Wht:         0.0,
+				Allowances: []Allowance{
+					{AllowanceType: "k-receipt", Amount: 200000.00},
+					{AllowanceType: "donation", Amount: 100000.00},
+				},
+			},
+			expectTax: 14000.0,
+		},
+		{
+			name: "Total income 500,000 WHT 0.0 k-receipt 30,000 should return 26,000",
+			input: CalculationRequest{
+				TotalIncome: 500000.0,
+				Wht:         0.0,
+				Allowances: []Allowance{
+					{AllowanceType: "k-receipt", Amount: 30000.00},
+				},
+			},
+			expectTax: 26000.0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tax, _ := Calculate(defaultDeductions, tc.input)
+
+			if tax != tc.expectTax {
+				t.Errorf("Expected %v, got %v", tc.expectTax, tax)
+			}
+		})
+	}
+}
+
 func TestCalculateTaxAndRefund(t *testing.T) {
 	testCases := []testCase{
 		{


### PR DESCRIPTION
### As user, I want to calculate my tax with tax level detail
ในฐานะผู้ใช้ ฉันต้องการคำนวนภาษีจาก ข้อมูลที่ส่งให้พร้อมค่าลดหย่อน พร้อมระบุรายละเอียดของขั้นบันใดภาษี

- [x] Add unit tests for support k-receipt allowance
- [x] Fix calculate tax function to support k-receipt allowance
- [x] Fix get tax levels function to support k-receipt allowance

##### Example Request
```json
{
  "totalIncome": 500000.0,
  "wht": 0.0,
  "allowances": [
    {
      "allowanceType": "k-receipt",
      "amount": 200000.0
    },
    {
      "allowanceType": "donation",
      "amount": 100000.0
    }
  ]
}
```
##### Example Response
```json
{
  "tax": 14000.0,
  "taxLevel": [
    {
      "level": "0-150,000",
      "tax": 0.0
    },
    {
      "level": "150,001-500,000",
      "tax": 14000.0
    },
    {
      "level": "500,001-1,000,000",
      "tax": 0.0
    },
    {
      "level": "1,000,001-2,000,000",
      "tax": 0.0
    },
    {
      "level": "2,000,001 ขึ้นไป",
      "tax": 0.0
    }
  ]
}
```